### PR TITLE
Add interactive Europe trip dashboard

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/app.js
+++ b/app.js
@@ -1,0 +1,80 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const password = 'eurotrip';
+  const loginSection = document.getElementById('login');
+  const dashboard = document.getElementById('dashboard');
+  const loginForm = document.getElementById('login-form');
+
+  loginForm.addEventListener('submit', (e) => {
+    e.preventDefault();
+    const input = document.getElementById('password').value;
+    if (input === password) {
+      loginSection.style.display = 'none';
+      dashboard.style.display = 'block';
+      initDashboard();
+    } else {
+      alert('Incorrect password');
+    }
+  });
+
+  function initDashboard() {
+    const today = new Date().toISOString().split('T')[0];
+    const day = TripLogic.getItineraryForDate(today);
+    displayItinerary(day);
+    if (navigator.geolocation) {
+      navigator.geolocation.getCurrentPosition((pos) => {
+        const lat = pos.coords.latitude;
+        const lon = pos.coords.longitude;
+        document.getElementById('location').textContent = `${lat.toFixed(4)}, ${lon.toFixed(4)}`;
+        if (day && day.accommodation) {
+          const mapsUrl = `https://www.google.com/maps/dir/?api=1&destination=${encodeURIComponent(day.accommodation.address)}&origin=${lat},${lon}`;
+          document.getElementById('maps-link').href = mapsUrl;
+        }
+        fetchSuggestions(lat, lon);
+      }, () => {
+        document.getElementById('location').textContent = 'Location unavailable';
+      });
+    }
+  }
+
+  function displayItinerary(day) {
+    const container = document.getElementById('itinerary');
+    if (!day) {
+      container.textContent = 'No itinerary for today';
+      return;
+    }
+    let html = '';
+    if (day.accommodation) {
+      html += `<h3>Accommodation</h3><p>${day.accommodation.name}<br>${day.accommodation.address}</p>`;
+    }
+    if (day.travel) {
+      html += `<h3>Travel</h3><p>${day.travel}</p>`;
+    }
+    if (day.activities && day.activities.length) {
+      html += '<h3>Activities</h3><ul>' +
+        day.activities.map(a => `<li>${a.start ? a.start + ' - ' : ''}${a.end ? a.end + ': ' : ''}${a.title}</li>`).join('') + '</ul>';
+    }
+    container.innerHTML = html;
+
+    const freeBlocks = TripLogic.getFreeTimeBlocks(day);
+    const freeContainer = document.getElementById('free-time');
+    if (freeBlocks.length > 0) {
+      freeContainer.innerHTML = '<h3>Free Time</h3><ul>' +
+        freeBlocks.map(b => `<li>${b.start} - ${b.end}</li>`).join('') + '</ul>';
+    } else {
+      freeContainer.textContent = 'No free time today';
+    }
+  }
+
+  function fetchSuggestions(lat, lon) {
+    const url = `https://en.wikipedia.org/w/api.php?action=query&list=geosearch&gscoord=${lat}%7C${lon}&gsradius=10000&gslimit=5&format=json&origin=*`;
+    fetch(url)
+      .then(res => res.json())
+      .then(data => {
+        const list = data.query.geosearch.map(p => `<li>${p.title}</li>`).join('');
+        document.getElementById('suggestions').innerHTML = '<h3>Nearby Activities</h3><ul>' + list + '</ul>';
+      })
+      .catch(() => {
+        document.getElementById('suggestions').textContent = 'Could not load suggestions';
+      });
+  }
+});

--- a/index.html
+++ b/index.html
@@ -1,1 +1,34 @@
-
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Europe Trip Dashboard</title>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <div id="login">
+    <form id="login-form">
+      <h2>Enter Password</h2>
+      <input type="password" id="password" />
+      <button type="submit">Enter</button>
+    </form>
+  </div>
+  <div id="dashboard">
+    <header>
+      <h1>Europe Trip Dashboard</h1>
+    </header>
+    <section>
+      <h2>Current Location</h2>
+      <p id="location">Detecting...</p>
+      <a id="maps-link" target="_blank">Directions to accommodation</a>
+    </section>
+    <section id="itinerary"></section>
+    <section id="free-time"></section>
+    <section id="suggestions"></section>
+  </div>
+  <script src="itinerary.js"></script>
+  <script src="logic.js"></script>
+  <script src="app.js"></script>
+</body>
+</html>

--- a/itinerary.js
+++ b/itinerary.js
@@ -1,0 +1,393 @@
+(function(global){
+  const itinerary = [
+    {
+      date: '2023-09-12',
+      travel: 'Brisbane, Australia > Singapore > Paris, France',
+      accommodation: null,
+      activities: []
+    },
+    {
+      date: '2023-09-13',
+      accommodation: {
+        name: 'Pullman Paris',
+        address: '18 Avenue De Suffren, Entrée au 22 rue Jean Rey, 15th arr., 75015 Paris, France',
+        checkIn: '16:00',
+        checkOut: null
+      },
+      activities: [
+        { start: '07:45', end: '08:45', title: 'Arrive Paris, France' },
+        { start: '09:00', end: '16:00', title: 'Uber from airport to Pullman, drop bags off, walk around Paris, sight see' }
+      ],
+      travel: null
+    },
+    {
+      date: '2023-09-14',
+      accommodation: {
+        name: 'Pullman Paris',
+        address: '18 Avenue De Suffren, Entrée au 22 rue Jean Rey, 15th arr., 75015 Paris, France',
+        checkIn: null,
+        checkOut: null
+      },
+      activities: [
+        { start: '08:45', end: '17:00', title: 'Paris in a Day Tour' }
+      ],
+      travel: null
+    },
+    {
+      date: '2023-09-15',
+      accommodation: {
+        name: 'Hotel Lafayette',
+        address: '6, rue Buffault, 9th arr., 75009 Paris, France',
+        checkIn: '15:00',
+        checkOut: '11:00'
+      },
+      activities: [
+        { start: '12:30', end: '15:00', title: 'Eiffel Tower visit' }
+      ],
+      travel: 'Check out Pullman Paris; move to Hotel Lafayette'
+    },
+    {
+      date: '2023-09-16',
+      accommodation: {
+        name: 'Hotel Lafayette',
+        address: '6, rue Buffault, 9th arr., 75009 Paris, France',
+        checkIn: null,
+        checkOut: null
+      },
+      activities: [
+        { start: '10:00', end: '16:00', title: 'Palace Versailles and Gardens tour' }
+      ],
+      travel: null
+    },
+    {
+      date: '2023-09-17',
+      accommodation: {
+        name: 'Hotel Lafayette',
+        address: '6, rue Buffault, 9th arr., 75009 Paris, France',
+        checkIn: null,
+        checkOut: null
+      },
+      activities: [
+        { start: '10:00', end: '12:00', title: 'Catacombs visit' }
+      ],
+      travel: null
+    },
+    {
+      date: '2023-09-18',
+      accommodation: {
+        name: 'a&o Berlin Mitte (Hostel)',
+        address: 'Köpenicker Str. 127-129, Mitte, 10179 Berlin, Germany',
+        checkIn: '15:00',
+        checkOut: null
+      },
+      activities: [],
+      travel: 'Paris, France > Berlin, Germany @ 07:35 (Arrive 09:20)'
+    },
+    {
+      date: '2023-09-19',
+      accommodation: {
+        name: 'a&o Berlin Mitte (Hostel)',
+        address: 'Köpenicker Str. 127-129, Mitte, 10179 Berlin, Germany',
+        checkIn: null,
+        checkOut: null
+      },
+      activities: [],
+      travel: null
+    },
+    {
+      date: '2023-09-20',
+      accommodation: {
+        name: 'a&o Berlin Mitte (Hostel)',
+        address: 'Köpenicker Str. 127-129, Mitte, 10179 Berlin, Germany',
+        checkIn: null,
+        checkOut: null
+      },
+      activities: [],
+      travel: null
+    },
+    {
+      date: '2023-09-21',
+      accommodation: {
+        name: 'Hotel al Graspo De Ua',
+        address: 'S. Marco 5094, San Marco, 30124 Venice, Italy',
+        checkIn: '14:00',
+        checkOut: null
+      },
+      activities: [],
+      travel: 'Berlin, Germany > Venice, Italy @ 18:15 (Arrive 19:55)'
+    },
+    {
+      date: '2023-09-22',
+      accommodation: {
+        name: 'Hotel al Graspo De Ua',
+        address: 'S. Marco 5094, San Marco, 30124 Venice, Italy',
+        checkIn: null,
+        checkOut: null
+      },
+      activities: [],
+      travel: null
+    },
+    {
+      date: '2023-09-23',
+      accommodation: {
+        name: 'Residence La Repubblica',
+        address: 'Piazza della Repubblica 4, 50123 Florence, Italy',
+        checkIn: '15:00',
+        checkOut: null
+      },
+      activities: [
+        { start: '11:26', end: '13:39', title: 'Train Venice to Florence' },
+        { start: '13:39', end: '23:59', title: 'Sight see' }
+      ],
+      travel: 'Venice, Italy > Florence, Italy @ 11:26 (Arrive 13:39)'
+    },
+    {
+      date: '2023-09-24',
+      accommodation: {
+        name: 'Residence La Repubblica',
+        address: 'Piazza della Repubblica 4, 50123 Florence, Italy',
+        checkIn: null,
+        checkOut: null
+      },
+      activities: [
+        { start: '07:45', end: '20:00', title: '12hr Tuscany Day Trip from Florence, Sienna, Pisa' }
+      ],
+      travel: null
+    },
+    {
+      date: '2023-09-25',
+      accommodation: {
+        name: 'Roman Holiday Suites',
+        address: '60 Via Machiavelli, Central Station, 00185 Rome, Italy',
+        checkIn: null,
+        checkOut: null
+      },
+      activities: [
+        { start: '12:48', end: '14:25', title: 'Train Florence to Rome' },
+        { start: '14:30', end: '23:59', title: 'Sight see' }
+      ],
+      travel: 'Florence, Italy > Rome, Italy @ 12:48 (Arrive 14:25)'
+    },
+    {
+      date: '2023-09-26',
+      accommodation: {
+        name: 'Roman Holiday Suites',
+        address: '60 Via Machiavelli, Central Station, 00185 Rome, Italy',
+        checkIn: null,
+        checkOut: null
+      },
+      activities: [
+        { start: '08:30', end: '17:00', title: 'Rome in a day tour' }
+      ],
+      travel: null
+    },
+    {
+      date: '2023-09-27',
+      accommodation: {
+        name: 'Roman Holiday Suites',
+        address: '60 Via Machiavelli, Central Station, 00185 Rome, Italy',
+        checkIn: null,
+        checkOut: null
+      },
+      activities: [
+        { start: '06:26', end: '08:29', title: 'Train Rome to Naples' },
+        { start: '18:30', end: '19:40', title: 'Train Naples to Rome' }
+      ],
+      travel: null
+    },
+    {
+      date: '2023-09-28',
+      accommodation: {
+        name: 'Roman Holiday Suites',
+        address: '60 Via Machiavelli, Central Station, 00185 Rome, Italy',
+        checkIn: null,
+        checkOut: null
+      },
+      activities: [],
+      travel: null
+    },
+    {
+      date: '2023-09-29',
+      accommodation: {
+        name: 'Hotel Des Victoires',
+        address: '204-212 Avenue Francis Tonner, Cannes La Bocca, 06150, France',
+        checkIn: null,
+        checkOut: null
+      },
+      activities: [
+        { start: '10:40', end: '11:50', title: 'Flight Rome to Nice' },
+        { start: '11:50', end: '13:00', title: 'Taxi to Cannes' }
+      ],
+      travel: 'Rome, Italy > Nice, France @ 10:40 (Arrive 11:50)'
+    },
+    {
+      date: '2023-09-30',
+      accommodation: {
+        name: 'Westminster Hotel & Spa Nice',
+        address: '27 Promenade Des Anglais Nice, France, 06000',
+        checkIn: null,
+        checkOut: null
+      },
+      activities: [
+        { start: '09:00', end: '10:00', title: 'Travel Cannes to Nice' }
+      ],
+      travel: null
+    },
+    {
+      date: '2023-10-01',
+      accommodation: {
+        name: 'Westminster Hotel & Spa Nice',
+        address: '27 Promenade Des Anglais Nice, France, 06000',
+        checkIn: null,
+        checkOut: null
+      },
+      activities: [
+        { start: '09:00', end: '10:00', title: 'Travel Nice to Monaco' },
+        { start: '18:00', end: '19:00', title: 'Travel Monaco to Nice' }
+      ],
+      travel: null
+    },
+    {
+      date: '2023-10-02',
+      accommodation: {
+        name: 'Catalunya',
+        address: 'Santa Anna, 24, Ciutat Vella, 08002 Barcelona, Spain',
+        checkIn: null,
+        checkOut: null
+      },
+      activities: [
+        { start: '11:40', end: '12:55', title: 'Flight Nice to Barcelona' }
+      ],
+      travel: 'Nice, France > Barcelona, Spain @ 11:40 (Arrive 12:55)'
+    },
+    {
+      date: '2023-10-03',
+      accommodation: {
+        name: 'Catalunya',
+        address: 'Santa Anna, 24, Ciutat Vella, 08002 Barcelona, Spain',
+        checkIn: null,
+        checkOut: null
+      },
+      activities: [],
+      travel: null
+    },
+    {
+      date: '2023-10-04',
+      accommodation: {
+        name: 'Catalunya',
+        address: 'Santa Anna, 24, Ciutat Vella, 08002 Barcelona, Spain',
+        checkIn: null,
+        checkOut: null
+      },
+      activities: [],
+      travel: null
+    },
+    {
+      date: '2023-10-05',
+      accommodation: {
+        name: 'Plaza Hotel Capitole Toulouse',
+        address: '7 Place du Capitole, 31000 Toulouse, France',
+        checkIn: null,
+        checkOut: null
+      },
+      activities: [
+        { start: '09:28', end: '11:37', title: 'Train Barcelona to Narbonne' },
+        { start: '13:02', end: '14:17', title: 'Train Narbonne to Toulouse' }
+      ],
+      travel: 'Barcelona, Spain > Narbonne, France @ 09:28 (Arrive 11:37); Narbonne, France > Toulouse, France @ 13:02 (Arrive 14:17)'
+    },
+    {
+      date: '2023-10-06',
+      accommodation: {
+        name: 'Plaza Hotel Capitole Toulouse',
+        address: '7 Place du Capitole, 31000 Toulouse, France',
+        checkIn: null,
+        checkOut: null
+      },
+      activities: [],
+      travel: null
+    },
+    {
+      date: '2023-10-07',
+      accommodation: {
+        name: '2 Place Saint-Projet',
+        address: '2 Place Saint-Projet, Bordeaux City-Centre, 33000 Bordeaux, France',
+        checkIn: null,
+        checkOut: null
+      },
+      activities: [
+        { start: '12:15', end: '14:40', title: 'Train Toulouse to Bordeaux' }
+      ],
+      travel: 'Toulouse, France > Bordeaux, France @ 12:15 (Arrive 14:40)'
+    },
+    {
+      date: '2023-10-08',
+      accommodation: {
+        name: '2 Place Saint-Projet',
+        address: '2 Place Saint-Projet, Bordeaux City-Centre, 33000 Bordeaux, France',
+        checkIn: null,
+        checkOut: null
+      },
+      activities: [],
+      travel: null
+    },
+    {
+      date: '2023-10-09',
+      accommodation: {
+        name: '2 Place Saint-Projet',
+        address: '2 Place Saint-Projet, Bordeaux City-Centre, 33000 Bordeaux, France',
+        checkIn: null,
+        checkOut: null
+      },
+      activities: [],
+      travel: null
+    },
+    {
+      date: '2023-10-10',
+      accommodation: {
+        name: '2 Rue de la Fronde',
+        address: '2 Rue de la Fronde, 5th arrondissement, 69005 Lyon, France',
+        checkIn: null,
+        checkOut: null
+      },
+      activities: [
+        { start: '15:15', end: '16:25', title: 'Flight Bordeaux to Lyon' }
+      ],
+      travel: 'Bordeaux, France > Lyon, France @ 15:15 (Arrive 16:25)'
+    },
+    {
+      date: '2023-10-11',
+      accommodation: {
+        name: '2 Rue de la Fronde',
+        address: '2 Rue de la Fronde, 5th arrondissement, 69005 Lyon, France',
+        checkIn: null,
+        checkOut: null
+      },
+      activities: [],
+      travel: null
+    },
+    {
+      date: '2023-10-12',
+      accommodation: {
+        name: '2 Rue de la Fronde',
+        address: '2 Rue de la Fronde, 5th arrondissement, 69005 Lyon, France',
+        checkIn: null,
+        checkOut: null
+      },
+      activities: [],
+      travel: null
+    },
+    {
+      date: '2023-10-13',
+      accommodation: null,
+      activities: [],
+      travel: 'Lyon, France > Paris, France @ 10:20 (Arrive 11:30); Paris, France > Singapore > Brisbane, Australia > Canberra, Australia'
+    }
+  ];
+
+  if (typeof module !== 'undefined' && module.exports) {
+    module.exports = itinerary;
+  } else {
+    global.itinerary = itinerary;
+  }
+})(this);

--- a/logic.js
+++ b/logic.js
@@ -1,0 +1,53 @@
+(function(global){
+  const itinerary = global.itinerary || require('./itinerary.js');
+
+  function getItineraryForDate(dateStr) {
+    return itinerary.find(day => day.date === dateStr);
+  }
+
+  function parseTime(str) {
+    const [h, m] = str.split(':').map(Number);
+    return h * 60 + m;
+  }
+
+  function getFreeTimeBlocks(day) {
+    if (!day || !day.activities) return [{ start: '00:00', end: '24:00' }];
+    const events = day.activities.filter(a => a.start && a.end)
+      .map(a => ({ start: parseTime(a.start), end: parseTime(a.end) }))
+      .sort((a, b) => a.start - b.start);
+    const blocks = [];
+    let cursor = 0;
+    for (const e of events) {
+      if (e.start > cursor) {
+        blocks.push({ start: minutesToStr(cursor), end: minutesToStr(e.start) });
+      }
+      if (e.end > cursor) cursor = e.end;
+    }
+    if (cursor < 24 * 60) {
+      blocks.push({ start: minutesToStr(cursor), end: '24:00' });
+    }
+    return blocks;
+  }
+
+  function minutesToStr(min) {
+    const h = String(Math.floor(min / 60)).padStart(2, '0');
+    const m = String(min % 60).padStart(2, '0');
+    return `${h}:${m}`;
+  }
+
+  function haversineDistance(lat1, lon1, lat2, lon2) {
+    function toRad(x) { return x * Math.PI / 180; }
+    const R = 6371;
+    const dLat = toRad(lat2 - lat1);
+    const dLon = toRad(lon2 - lon1);
+    const a = Math.sin(dLat/2) ** 2 + Math.cos(toRad(lat1)) * Math.cos(toRad(lat2)) * Math.sin(dLon/2) ** 2;
+    const c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1-a));
+    return R * c;
+  }
+
+  if (typeof module !== 'undefined' && module.exports) {
+    module.exports = { getItineraryForDate, getFreeTimeBlocks, haversineDistance };
+  } else {
+    global.TripLogic = { getItineraryForDate, getFreeTimeBlocks, haversineDistance };
+  }
+})(this);

--- a/package.json
+++ b/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "europe-trip-dashboard",
+  "version": "1.0.0",
+  "description": "Interactive dashboard for Europe trip itinerary",
+  "scripts": {
+    "test": "node tests/logic.test.js"
+  }
+}

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,48 @@
+body {
+  font-family: Arial, sans-serif;
+  background: #f5f5f5;
+  color: #333;
+  margin: 0;
+}
+
+header {
+  background: #4a90e2;
+  color: white;
+  padding: 1rem;
+  text-align: center;
+}
+
+#dashboard {
+  display: none;
+  padding: 1rem;
+}
+
+section {
+  margin-bottom: 1.5rem;
+  background: white;
+  padding: 1rem;
+  border-radius: 8px;
+  box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+}
+
+#login {
+  display: flex;
+  height: 100vh;
+  justify-content: center;
+  align-items: center;
+}
+
+#login form {
+  background: white;
+  padding: 2rem;
+  border-radius: 8px;
+  box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+}
+
+button {
+  padding: 0.5rem 1rem;
+  background: #4a90e2;
+  color: white;
+  border: none;
+  border-radius: 4px;
+}

--- a/tests/logic.test.js
+++ b/tests/logic.test.js
@@ -1,0 +1,22 @@
+const assert = require('assert');
+const { getItineraryForDate, getFreeTimeBlocks } = require('../logic.js');
+
+// Test itinerary retrieval
+const day = getItineraryForDate('2023-09-14');
+assert(day.accommodation.name.includes('Pullman Paris'), 'Itinerary lookup failed');
+
+// Test free time calculation
+const sampleDay = {
+  activities: [
+    { start: '08:00', end: '10:00', title: 'Morning tour' },
+    { start: '13:00', end: '14:00', title: 'Lunch' }
+  ]
+};
+const blocks = getFreeTimeBlocks(sampleDay);
+assert.deepStrictEqual(blocks, [
+  { start: '00:00', end: '08:00' },
+  { start: '10:00', end: '13:00' },
+  { start: '14:00', end: '24:00' }
+], 'Free time calculation failed');
+
+console.log('All tests passed');


### PR DESCRIPTION
## Summary
- build password-protected dashboard that shows today's location, itinerary and nearby suggestions
- include full multi-country itinerary data and logic for calculating free time
- add Node-based tests to verify itinerary lookup and free time computation

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a813f27aec83288ef05fafca36b935