### PR TITLE
Add server-side token-based login

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,13 +1,36 @@
 document.addEventListener('DOMContentLoaded', () => {
-  const password = 'eurotrip';
   const loginSection = document.getElementById('login');
   const dashboard = document.getElementById('dashboard');
   const loginForm = document.getElementById('login-form');
 
-  loginForm.addEventListener('submit', (e) => {
+  async function attemptAutoLogin() {
+    const token = localStorage.getItem('token');
+    if (!token) return;
+    const res = await fetch('/api/validate', {
+      headers: { 'Authorization': `Bearer ${token}` }
+    });
+    if (res.ok) {
+      loginSection.style.display = 'none';
+      dashboard.style.display = 'block';
+      initDashboard();
+    } else {
+      localStorage.removeItem('token');
+    }
+  }
+
+  attemptAutoLogin();
+
+  loginForm.addEventListener('submit', async (e) => {
     e.preventDefault();
     const input = document.getElementById('password').value;
-    if (input === password) {
+    const res = await fetch('/api/login', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ password: input })
+    });
+    if (res.ok) {
+      const data = await res.json();
+      localStorage.setItem('token', data.token);
       loginSection.style.display = 'none';
       dashboard.style.display = 'block';
       initDashboard();

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "description": "Interactive dashboard for Europe trip itinerary",
   "scripts": {
-    "test": "node tests/logic.test.js"
+    "test": "node tests/logic.test.js && node tests/login.test.js",
+    "start": "node server.js"
   }
 }

--- a/server.js
+++ b/server.js
@@ -1,0 +1,73 @@
+const http = require('http');
+const fs = require('fs');
+const path = require('path');
+const crypto = require('crypto');
+
+const hashedPassword = crypto.createHash('sha256').update('eurotrip').digest('hex');
+const sessions = new Set();
+
+function handleApi(req, res) {
+  if (req.method === 'POST' && req.url === '/api/login') {
+    let body = '';
+    req.on('data', chunk => body += chunk);
+    req.on('end', () => {
+      try {
+        const { password } = JSON.parse(body || '{}');
+        const hashed = crypto.createHash('sha256').update(password || '').digest('hex');
+        if (hashed === hashedPassword) {
+          const token = crypto.randomBytes(16).toString('hex');
+          sessions.add(token);
+          res.writeHead(200, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify({ token }));
+        } else {
+          res.writeHead(401, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify({ error: 'Invalid credentials' }));
+        }
+      } catch {
+        res.writeHead(400, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ error: 'Bad request' }));
+      }
+    });
+    return true;
+  }
+  if (req.method === 'GET' && req.url === '/api/validate') {
+    const auth = req.headers['authorization'] || '';
+    const token = auth.replace('Bearer ', '');
+    if (sessions.has(token)) {
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ valid: true }));
+    } else {
+      res.writeHead(401, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ valid: false }));
+    }
+    return true;
+  }
+  return false;
+}
+
+const server = http.createServer((req, res) => {
+  if (handleApi(req, res)) return;
+  const filePath = path.join(__dirname, req.url === '/' ? 'index.html' : req.url);
+  fs.readFile(filePath, (err, data) => {
+    if (err) {
+      res.writeHead(404);
+      res.end('Not found');
+    } else {
+      const ext = path.extname(filePath).toLowerCase();
+      const types = {
+        '.html': 'text/html',
+        '.js': 'text/javascript',
+        '.css': 'text/css',
+        '.json': 'application/json'
+      };
+      res.writeHead(200, { 'Content-Type': types[ext] || 'application/octet-stream' });
+      res.end(data);
+    }
+  });
+});
+
+if (require.main === module) {
+  server.listen(3000, () => console.log('Server running on port 3000'));
+}
+
+module.exports = { server, sessions };

--- a/tests/login.test.js
+++ b/tests/login.test.js
@@ -1,0 +1,31 @@
+const assert = require('assert');
+const { server } = require('../server.js');
+
+(async () => {
+  const srv = server.listen(0);
+  const port = srv.address().port;
+
+  let res = await fetch(`http://localhost:${port}/api/login`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ password: 'wrong' })
+  });
+  assert.strictEqual(res.status, 401, 'Should reject invalid password');
+
+  res = await fetch(`http://localhost:${port}/api/login`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ password: 'eurotrip' })
+  });
+  assert.strictEqual(res.status, 200, 'Login should succeed');
+  const data = await res.json();
+  assert.ok(data.token, 'Token missing');
+
+  res = await fetch(`http://localhost:${port}/api/validate`, {
+    headers: { 'Authorization': `Bearer ${data.token}` }
+  });
+  assert.strictEqual(res.status, 200, 'Token validation failed');
+
+  srv.close();
+  console.log('Login tests passed');
+})();


### PR DESCRIPTION
## Summary
- Add HTTP server with hashed password and token-based authentication
- Update client to log in via fetch and hide dashboard unless session token is valid
- Introduce automated login tests and expand npm test script

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a8179350948328acd79f4d5a7de637