### PR TITLE
Improve password form accessibility with tests

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,8 +10,11 @@
   <div id="login">
     <form id="login-form">
       <h2>Enter Password</h2>
-      <input type="password" id="password" />
-      <button type="submit">Enter</button>
+      <label for="password">Password
+        <input type="password" id="password" aria-describedby="password-hint" />
+      </label>
+      <p id="password-hint">Enter the password to access the dashboard.</p>
+      <button type="submit" aria-label="Submit password">Enter</button>
     </form>
   </div>
   <div id="dashboard">

--- a/package.json
+++ b/package.json
@@ -3,6 +3,6 @@
   "version": "1.0.0",
   "description": "Interactive dashboard for Europe trip itinerary",
   "scripts": {
-    "test": "node tests/logic.test.js"
+    "test": "node tests/logic.test.js && node tests/index.test.js"
   }
 }

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -1,0 +1,15 @@
+const assert = require('assert');
+const fs = require('fs');
+
+const html = fs.readFileSync('index.html', 'utf8');
+
+const labelRegex = /<label[^>]*for="password"[^>]*>\s*Password\s*<input[^>]*id="password"[^>]*aria-describedby="password-hint"[^>]*>\s*<\/label>/i;
+assert(labelRegex.test(html), 'Password input not wrapped in label with aria-describedby');
+
+const hintRegex = /<p[^>]*id="password-hint"[^>]*>.*?<\/p>/i;
+assert(hintRegex.test(html), 'Password hint missing');
+
+const buttonRegex = /<button[^>]*type="submit"[^>]*aria-label="Submit password"[^>]*>\s*Enter\s*<\/button>/i;
+assert(buttonRegex.test(html), 'Submit button missing aria-label');
+
+console.log('index.html accessibility tests passed');


### PR DESCRIPTION
## Summary
- Wrap password field with a label and add hint and aria attributes for better accessibility
- Give submit button an aria-label for clarity
- Add automated test to ensure password form accessibility

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a8179599ec832891049915fc6ecadc