### PR TITLE
feat: allow manual location entry

### DIFF
--- a/index.html
+++ b/index.html
@@ -21,6 +21,10 @@
     <section>
       <h2>Current Location</h2>
       <p id="location">Detecting...</p>
+      <div id="manual-location-container" style="display:none">
+        <input id="manual-location" placeholder="lat,lon" />
+        <button id="set-location" type="button">Set Location</button>
+      </div>
       <a id="maps-link" target="_blank">Directions to accommodation</a>
     </section>
     <section id="itinerary"></section>


### PR DESCRIPTION
## Summary
- add manual location input for use when geolocation fails
- persist manual coordinates in localStorage and reuse in dashboard

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a81793c9408328bf6e441f0035c164