### PR TITLE
Use local timezone for itinerary retrieval

### DIFF
--- a/app.js
+++ b/app.js
@@ -17,7 +17,7 @@ document.addEventListener('DOMContentLoaded', () => {
   });
 
   function initDashboard() {
-    const today = new Date().toISOString().split('T')[0];
+    const today = TripLogic.getLocalDateString();
     const day = TripLogic.getItineraryForDate(today);
     displayItinerary(day);
     if (navigator.geolocation) {

--- a/logic.js
+++ b/logic.js
@@ -5,6 +5,10 @@
     return itinerary.find(day => day.date === dateStr);
   }
 
+  function getLocalDateString(date = new Date(), timeZone) {
+    return new Intl.DateTimeFormat('en-CA', { timeZone }).format(date);
+  }
+
   function parseTime(str) {
     const [h, m] = str.split(':').map(Number);
     return h * 60 + m;
@@ -46,8 +50,8 @@
   }
 
   if (typeof module !== 'undefined' && module.exports) {
-    module.exports = { getItineraryForDate, getFreeTimeBlocks, haversineDistance };
+    module.exports = { getItineraryForDate, getLocalDateString, getFreeTimeBlocks, haversineDistance };
   } else {
-    global.TripLogic = { getItineraryForDate, getFreeTimeBlocks, haversineDistance };
+    global.TripLogic = { getItineraryForDate, getLocalDateString, getFreeTimeBlocks, haversineDistance };
   }
 })(this);

--- a/tests/logic.test.js
+++ b/tests/logic.test.js
@@ -1,9 +1,14 @@
 const assert = require('assert');
-const { getItineraryForDate, getFreeTimeBlocks } = require('../logic.js');
+const { getItineraryForDate, getFreeTimeBlocks, getLocalDateString } = require('../logic.js');
 
 // Test itinerary retrieval
 const day = getItineraryForDate('2023-09-14');
 assert(day.accommodation.name.includes('Pullman Paris'), 'Itinerary lookup failed');
+
+// Test local date retrieval across time zones
+const date = new Date('2023-09-13T23:00:00Z');
+assert.strictEqual(getLocalDateString(date, 'America/New_York'), '2023-09-13', 'NY date conversion failed');
+assert.strictEqual(getLocalDateString(date, 'Europe/Paris'), '2023-09-14', 'Paris date conversion failed');
 
 // Test free time calculation
 const sampleDay = {


### PR DESCRIPTION
## Summary
- derive local date strings with `Intl.DateTimeFormat`
- call `getItineraryForDate` using localized date
- test local date handling across time zones

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a81797816083289b222a760671245c