### PR TITLE
Optimize itinerary lookup for date-based access

### DIFF
--- a/itinerary.js
+++ b/itinerary.js
@@ -1,5 +1,5 @@
 (function(global){
-  const itinerary = [
+  const itineraryArray = [
     {
       date: '2023-09-12',
       travel: 'Brisbane, Australia > Singapore > Paris, France',
@@ -384,6 +384,11 @@
       travel: 'Lyon, France > Paris, France @ 10:20 (Arrive 11:30); Paris, France > Singapore > Brisbane, Australia > Canberra, Australia'
     }
   ];
+
+  const itinerary = itineraryArray.reduce((acc, { date, ...rest }) => {
+    acc[date] = rest;
+    return acc;
+  }, {});
 
   if (typeof module !== 'undefined' && module.exports) {
     module.exports = itinerary;

--- a/logic.js
+++ b/logic.js
@@ -2,7 +2,7 @@
   const itinerary = global.itinerary || require('./itinerary.js');
 
   function getItineraryForDate(dateStr) {
-    return itinerary.find(day => day.date === dateStr);
+    return itinerary[dateStr];
   }
 
   function parseTime(str) {

--- a/tests/logic.test.js
+++ b/tests/logic.test.js
@@ -1,9 +1,12 @@
 const assert = require('assert');
 const { getItineraryForDate, getFreeTimeBlocks } = require('../logic.js');
+const itinerary = require('../itinerary.js');
 
-// Test itinerary retrieval
+// Test itinerary retrieval from object structure
+const directDay = itinerary['2023-09-14'];
+assert(directDay.accommodation.name.includes('Pullman Paris'), 'Direct itinerary lookup failed');
 const day = getItineraryForDate('2023-09-14');
-assert(day.accommodation.name.includes('Pullman Paris'), 'Itinerary lookup failed');
+assert.strictEqual(day, directDay, 'getItineraryForDate should retrieve using date key');
 
 // Test free time calculation
 const sampleDay = {


### PR DESCRIPTION
## Summary
- preprocess itinerary data into an object keyed by date for constant-time lookups
- update `getItineraryForDate` to access entries directly via date keys
- extend tests to validate object lookup and updated retrieval logic

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a81795ba448328a67e19642f3be036