### PR TITLE
Add responsive layout and dark mode

### DIFF
--- a/app.js
+++ b/app.js
@@ -9,7 +9,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const input = document.getElementById('password').value;
     if (input === password) {
       loginSection.style.display = 'none';
-      dashboard.style.display = 'block';
+      dashboard.classList.add('active');
       initDashboard();
     } else {
       alert('Incorrect password');

--- a/styles.css
+++ b/styles.css
@@ -3,6 +3,7 @@ body {
   background: #f5f5f5;
   color: #333;
   margin: 0;
+  font-size: 16px;
 }
 
 header {
@@ -15,6 +16,12 @@ header {
 #dashboard {
   display: none;
   padding: 1rem;
+  gap: 1rem;
+}
+
+#dashboard.active {
+  display: grid;
+  grid-template-columns: 1fr;
 }
 
 section {
@@ -45,4 +52,44 @@ button {
   color: white;
   border: none;
   border-radius: 4px;
+}
+
+@media (max-width: 600px) {
+  body {
+    font-size: 14px;
+  }
+}
+
+@media (min-width: 601px) and (max-width: 900px) {
+  body {
+    font-size: 15px;
+  }
+  #dashboard.active {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+
+@media (min-width: 901px) {
+  #dashboard.active {
+    grid-template-columns: repeat(3, 1fr);
+  }
+}
+
+@media (prefers-color-scheme: dark) {
+  body {
+    background: #121212;
+    color: #f5f5f5;
+  }
+  header {
+    background: #1e1e1e;
+    color: #f5f5f5;
+  }
+  section {
+    background: #1e1e1e;
+    box-shadow: 0 2px 4px rgba(0,0,0,0.5);
+  }
+  button {
+    background: #333;
+    color: #f5f5f5;
+  }
 }


### PR DESCRIPTION
## Summary
- add CSS grid-based layout with responsive media queries for phones and tablets
- support dark mode via `prefers-color-scheme`
- show dashboard by activating new grid class after login

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a81797895c8328a9ae67d2465434b2