### PR TITLE
Implement JWT auth, session expiry, and rate limiting

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,8 +3,10 @@
   "version": "1.0.0",
   "description": "Interactive dashboard for Europe trip itinerary",
   "scripts": {
-    "test": "node tests/logic.test.js && node tests/index.test.js"
-    "test": "node tests/logic.test.js && node tests/login.test.js",
+    "test": "node tests/logic.test.js && node tests/index.test.js && node tests/login.test.js",
     "start": "node server.js"
+  },
+  "dependencies": {
+    "jsonwebtoken": "^9.0.0"
   }
 }

--- a/server.js
+++ b/server.js
@@ -2,12 +2,44 @@ const http = require('http');
 const fs = require('fs');
 const path = require('path');
 const crypto = require('crypto');
+const jwt = require('jsonwebtoken');
 
-const hashedPassword = crypto.createHash('sha256').update('eurotrip').digest('hex');
-const sessions = new Set();
+const hashedPassword = process.env.HASHED_PASSWORD || '';
+const jwtSecret = process.env.JWT_SECRET || 'secret';
+const TOKEN_EXPIRY_SECONDS = parseInt(process.env.TOKEN_EXPIRY_SECONDS, 10) || 3600;
+
+const sessions = new Map(); // token -> expiry timestamp
+const rateLimit = new Map(); // ip -> { count, start }
+const RATE_LIMIT_MAX = 5;
+const RATE_LIMIT_WINDOW_MS = 60000;
+
+function isRateLimited(ip) {
+  const now = Date.now();
+  const record = rateLimit.get(ip) || { count: 0, start: now };
+  if (now - record.start > RATE_LIMIT_WINDOW_MS) {
+    record.count = 0;
+    record.start = now;
+  }
+  record.count++;
+  rateLimit.set(ip, record);
+  return record.count > RATE_LIMIT_MAX;
+}
+
+function purgeSessions() {
+  const now = Date.now();
+  for (const [token, exp] of sessions.entries()) {
+    if (exp <= now) sessions.delete(token);
+  }
+}
 
 function handleApi(req, res) {
   if (req.method === 'POST' && req.url === '/api/login') {
+    const ip = req.socket.remoteAddress;
+    if (isRateLimited(ip)) {
+      res.writeHead(429, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ error: 'Too many requests' }));
+      return true;
+    }
     let body = '';
     req.on('data', chunk => body += chunk);
     req.on('end', () => {
@@ -15,8 +47,9 @@ function handleApi(req, res) {
         const { password } = JSON.parse(body || '{}');
         const hashed = crypto.createHash('sha256').update(password || '').digest('hex');
         if (hashed === hashedPassword) {
-          const token = crypto.randomBytes(16).toString('hex');
-          sessions.add(token);
+          const token = jwt.sign({ sid: crypto.randomBytes(8).toString('hex') }, jwtSecret, { expiresIn: TOKEN_EXPIRY_SECONDS });
+          const expiry = Date.now() + TOKEN_EXPIRY_SECONDS * 1000;
+          sessions.set(token, expiry);
           res.writeHead(200, { 'Content-Type': 'application/json' });
           res.end(JSON.stringify({ token }));
         } else {
@@ -31,11 +64,19 @@ function handleApi(req, res) {
     return true;
   }
   if (req.method === 'GET' && req.url === '/api/validate') {
+    purgeSessions();
     const auth = req.headers['authorization'] || '';
     const token = auth.replace('Bearer ', '');
     if (sessions.has(token)) {
-      res.writeHead(200, { 'Content-Type': 'application/json' });
-      res.end(JSON.stringify({ valid: true }));
+      try {
+        jwt.verify(token, jwtSecret);
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ valid: true }));
+      } catch {
+        sessions.delete(token);
+        res.writeHead(401, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ valid: false }));
+      }
     } else {
       res.writeHead(401, { 'Content-Type': 'application/json' });
       res.end(JSON.stringify({ valid: false }));
@@ -46,6 +87,12 @@ function handleApi(req, res) {
 }
 
 const server = http.createServer((req, res) => {
+  const isSecure = req.headers['x-forwarded-proto'] === 'https' || req.socket.encrypted;
+  if (!isSecure) {
+    res.writeHead(301, { Location: `https://${req.headers.host}${req.url}` });
+    res.end();
+    return;
+  }
   if (handleApi(req, res)) return;
   const filePath = path.join(__dirname, req.url === '/' ? 'index.html' : req.url);
   fs.readFile(filePath, (err, data) => {
@@ -70,4 +117,4 @@ if (require.main === module) {
   server.listen(3000, () => console.log('Server running on port 3000'));
 }
 
-module.exports = { server, sessions };
+module.exports = { server, sessions, rateLimit };

--- a/tests/logic.test.js
+++ b/tests/logic.test.js
@@ -1,5 +1,6 @@
 const assert = require('assert');
-const { getItineraryForDate, getFreeTimeBlocks, haversineDistance } = require('../logic.js');
+const { getItineraryForDate, getFreeTimeBlocks, haversineDistance, getLocalDateString } = require('../logic.js');
+const itinerary = require('../itinerary.js');
 
 function createMockDocument() {
   const elements = {};
@@ -12,9 +13,6 @@ function createMockDocument() {
     elements
   };
 }
-const { getItineraryForDate, getFreeTimeBlocks } = require('../logic.js');
-const itinerary = require('../itinerary.js');
-const { getItineraryForDate, getFreeTimeBlocks, getLocalDateString } = require('../logic.js');
 
 // Test itinerary retrieval from object structure
 const directDay = itinerary['2023-09-14'];

--- a/tests/login.test.js
+++ b/tests/login.test.js
@@ -1,20 +1,27 @@
 const assert = require('assert');
-const { server } = require('../server.js');
+const crypto = require('crypto');
+
+process.env.HASHED_PASSWORD = crypto.createHash('sha256').update('eurotrip').digest('hex');
+process.env.JWT_SECRET = 'testsecret';
+process.env.TOKEN_EXPIRY_SECONDS = '1';
+
+const { server, sessions, rateLimit } = require('../server.js');
 
 (async () => {
   const srv = server.listen(0);
   const port = srv.address().port;
+  const headers = { 'Content-Type': 'application/json', 'x-forwarded-proto': 'https' };
 
   let res = await fetch(`http://localhost:${port}/api/login`, {
     method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
+    headers,
     body: JSON.stringify({ password: 'wrong' })
   });
   assert.strictEqual(res.status, 401, 'Should reject invalid password');
 
   res = await fetch(`http://localhost:${port}/api/login`, {
     method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
+    headers,
     body: JSON.stringify({ password: 'eurotrip' })
   });
   assert.strictEqual(res.status, 200, 'Login should succeed');
@@ -22,9 +29,34 @@ const { server } = require('../server.js');
   assert.ok(data.token, 'Token missing');
 
   res = await fetch(`http://localhost:${port}/api/validate`, {
-    headers: { 'Authorization': `Bearer ${data.token}` }
+    headers: { Authorization: `Bearer ${data.token}`, 'x-forwarded-proto': 'https' }
   });
   assert.strictEqual(res.status, 200, 'Token validation failed');
+
+  await new Promise(r => setTimeout(r, 1100));
+  res = await fetch(`http://localhost:${port}/api/validate`, {
+    headers: { Authorization: `Bearer ${data.token}`, 'x-forwarded-proto': 'https' }
+  });
+  assert.strictEqual(res.status, 401, 'Expired token should be rejected');
+  assert.strictEqual(sessions.size, 0, 'Expired session not purged');
+
+  rateLimit.clear();
+  let lastStatus;
+  for (let i = 0; i < 5; i++) {
+    res = await fetch(`http://localhost:${port}/api/login`, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify({ password: 'wrong' })
+    });
+    lastStatus = res.status;
+  }
+  assert.strictEqual(lastStatus, 401, 'Pre-limit attempts should be processed');
+  res = await fetch(`http://localhost:${port}/api/login`, {
+    method: 'POST',
+    headers,
+    body: JSON.stringify({ password: 'wrong' })
+  });
+  assert.strictEqual(res.status, 429, 'Should rate limit after too many requests');
 
   srv.close();
   console.log('Login tests passed');


### PR DESCRIPTION
## Summary
- Read hashed password from `HASHED_PASSWORD` env var and issue expiring JWTs
- Track sessions with expiration, purge expired tokens, and add basic rate limiting and HTTPS enforcement
- Add tests for login rejection, token expiration, and rate limiting

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a81b13de2083288b283612696dd7f5