### PR TITLE
Add map with manual fallback and integration tests

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Europe Trip Dashboard</title>
   <link rel="stylesheet" href="styles.css" />
+  <link href="https://api.mapbox.com/mapbox-gl-js/v2.15.0/mapbox-gl.css" rel="stylesheet" />
 </head>
 <body>
   <div id="login">
@@ -29,6 +30,7 @@
         <button id="set-location" type="button">Set Location</button>
       </div>
       <a id="maps-link" target="_blank">Directions to accommodation</a>
+      <div id="map" style="height:300px"></div>
     </section>
     <section id="itinerary"></section>
     <section id="free-time"></section>
@@ -36,6 +38,7 @@
   </div>
   <script src="itinerary.js"></script>
   <script src="logic.js"></script>
+  <script src="https://api.mapbox.com/mapbox-gl-js/v2.15.0/mapbox-gl.js"></script>
   <script src="app.js"></script>
 </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -3,8 +3,7 @@
   "version": "1.0.0",
   "description": "Interactive dashboard for Europe trip itinerary",
   "scripts": {
-    "test": "node tests/logic.test.js && node tests/index.test.js"
-    "test": "node tests/logic.test.js && node tests/login.test.js",
+    "test": "node tests/index.test.js && node tests/logic.test.js && node tests/login.test.js && node tests/map.test.js",
     "start": "node server.js"
   }
 }

--- a/tests/logic.test.js
+++ b/tests/logic.test.js
@@ -1,20 +1,26 @@
 const assert = require('assert');
-const { getItineraryForDate, getFreeTimeBlocks, haversineDistance } = require('../logic.js');
+const { getItineraryForDate, getFreeTimeBlocks, getLocalDateString, haversineDistance } = require('../logic.js');
+const itinerary = require('../itinerary.js');
 
 function createMockDocument() {
   const elements = {};
   return {
     getElementById: (id) => {
-      if (!elements[id]) elements[id] = { textContent: '', innerHTML: '', href: '' };
+      if (!elements[id]) elements[id] = {
+        textContent: '',
+        innerHTML: '',
+        href: '',
+        style: {},
+        value: '',
+        addEventListener: function (event, fn) { this['on' + event] = fn; },
+        trigger: function (event) { if (this['on' + event]) this['on' + event](); }
+      };
       return elements[id];
     },
     addEventListener: () => {},
     elements
   };
 }
-const { getItineraryForDate, getFreeTimeBlocks } = require('../logic.js');
-const itinerary = require('../itinerary.js');
-const { getItineraryForDate, getFreeTimeBlocks, getLocalDateString } = require('../logic.js');
 
 // Test itinerary retrieval from object structure
 const directDay = itinerary['2023-09-14'];

--- a/tests/map.test.js
+++ b/tests/map.test.js
@@ -1,0 +1,88 @@
+const assert = require('assert');
+
+function createMockDocument() {
+  const elements = {};
+  return {
+    getElementById: (id) => {
+      if (!elements[id]) elements[id] = {
+        textContent: '',
+        innerHTML: '',
+        href: '',
+        style: {},
+        value: '',
+        addEventListener: function (event, fn) { this['on' + event] = fn; },
+        trigger: function (event) { if (this['on' + event]) this['on' + event](); }
+      };
+      return elements[id];
+    },
+    addEventListener: () => {},
+    elements
+  };
+}
+
+class MockMap {
+  constructor(opts) {
+    this.center = opts.center;
+    this.markers = [];
+    global.__mapInstance = this;
+  }
+  setCenter(center) { this.center = center; }
+}
+
+class MockMarker {
+  constructor(opts) { this.color = opts && opts.color; }
+  setLngLat(ll) { this.lngLat = ll; return this; }
+  addTo(map) { map.markers.push(this); return this; }
+}
+
+// Geolocation success places user and accommodation markers
+{
+  const document = createMockDocument();
+  global.document = document;
+  global.fetch = () => ({
+    then: (resFn) => {
+      resFn({ json: () => ({}) });
+      return { then: (dataFn) => { dataFn({ query: { geosearch: [] } }); return { catch: () => {} }; } };
+    }
+  });
+  global.TripLogic = {
+    getItineraryForDate: () => ({ accommodation: { address: 'A', lat: 30, lon: 40 }, activities: [] }),
+    getFreeTimeBlocks: () => []
+  };
+  global.navigator = { geolocation: { getCurrentPosition: (succ) => succ({ coords: { latitude: 10, longitude: 20 } }) } };
+  global.mapboxgl = { Map: MockMap, Marker: MockMarker };
+  const { initDashboard } = require('../app.js');
+  initDashboard();
+  assert.deepStrictEqual(global.__mapInstance.center, [20, 10], 'Map not centered on user');
+  assert.deepStrictEqual(global.__mapInstance.markers.map(m => m.lngLat), [[20,10],[40,30]], 'Markers not placed');
+  delete global.document; delete global.fetch; delete global.TripLogic; delete global.navigator; delete global.mapboxgl; delete global.__mapInstance;
+  delete require.cache[require.resolve('../app.js')];
+}
+
+// Manual coordinate fallback when geolocation fails
+{
+  const document = createMockDocument();
+  global.document = document;
+  global.fetch = () => ({
+    then: (resFn) => {
+      resFn({ json: () => ({}) });
+      return { then: (dataFn) => { dataFn({ query: { geosearch: [] } }); return { catch: () => {} }; } };
+    }
+  });
+  global.TripLogic = {
+    getItineraryForDate: () => ({ accommodation: { address: 'A', lat: 5, lon: 6 }, activities: [] }),
+    getFreeTimeBlocks: () => []
+  };
+  global.navigator = { geolocation: { getCurrentPosition: (succ, err) => err() } };
+  global.mapboxgl = { Map: MockMap, Marker: MockMarker };
+  const { initDashboard } = require('../app.js');
+  initDashboard();
+  document.getElementById('manual-location').value = '1,2';
+  document.getElementById('set-location').trigger('click');
+  assert.deepStrictEqual(global.__mapInstance.center, [2,1], 'Manual coordinates not applied');
+  assert.deepStrictEqual(global.__mapInstance.markers.map(m => m.lngLat)[0], [2,1], 'User marker not updated');
+  delete global.document; delete global.fetch; delete global.TripLogic; delete global.navigator; delete global.mapboxgl; delete global.__mapInstance;
+  delete require.cache[require.resolve('../app.js')];
+}
+
+console.log('Map integration tests passed');


### PR DESCRIPTION
## Summary
- Embed Mapbox map container and library in dashboard
- Initialize map with user and accommodation markers, with manual coordinate fallback
- Add integration tests mocking map to verify markers

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a81b15d16083288f3fb2b46fbf3404