### PR TITLE
Add directions route list with API mocks

### DIFF
--- a/app.js
+++ b/app.js
@@ -9,9 +9,12 @@ function initDashboard() {
       document.getElementById('location').textContent = `${lat.toFixed(4)}, ${lon.toFixed(4)}`;
       if (day && day.accommodation) {
         const mapsUrl = `https://www.google.com/maps/dir/?api=1&destination=${encodeURIComponent(day.accommodation.address)}&origin=${lat},${lon}`;
-        document.getElementById('maps-link').href = mapsUrl;
+      document.getElementById('maps-link').href = mapsUrl;
       }
       fetchSuggestions(lat, lon);
+      if (day && day.accommodation) {
+        loadRoutes(lat, lon, day.accommodation.address);
+      }
     }, () => {
       document.getElementById('location').textContent = 'Location unavailable';
     });
@@ -60,6 +63,30 @@ function fetchSuggestions(lat, lon) {
     });
 }
 
+async function loadRoutes(lat, lon, destination) {
+  const container = document.getElementById('routes');
+  if (!container || !destination) return;
+  const modes = [
+    { mode: 'transit', label: 'Transit', link: `https://www.google.com/maps/dir/?api=1&origin=${lat},${lon}&destination=${encodeURIComponent(destination)}&travelmode=transit` },
+    { mode: 'walking', label: 'Walking', link: `https://www.google.com/maps/dir/?api=1&origin=${lat},${lon}&destination=${encodeURIComponent(destination)}&travelmode=walking` },
+    { mode: 'driving', label: 'Taxi/Ride-share', link: `https://m.uber.com/ul/?action=setPickup&pickup[latitude]=${lat}&pickup[longitude]=${lon}&dropoff[formatted_address]=${encodeURIComponent(destination)}` }
+  ];
+  try {
+    const base = `https://maps.googleapis.com/maps/api/directions/json?origin=${lat},${lon}&destination=${encodeURIComponent(destination)}`;
+    const results = await Promise.all(modes.map(async m => {
+      const res = await fetch(`${base}&mode=${m.mode}`);
+      const json = await res.json();
+      const duration = json.routes && json.routes[0] && json.routes[0].legs && json.routes[0].legs[0] && json.routes[0].legs[0].duration && json.routes[0].legs[0].duration.text ? json.routes[0].legs[0].duration.text : 'N/A';
+      return { label: m.label, duration, link: m.link };
+    }));
+    container.innerHTML = '<h3>Routes</h3><ul>' +
+      results.map(r => `<li>${r.label}: ${r.duration} - <a href="${r.link}" target="_blank">Open in ${r.label === 'Taxi/Ride-share' ? 'Uber' : 'Maps'}</a></li>`).join('') +
+      '</ul>';
+  } catch (e) {
+    container.textContent = 'Could not load route information';
+  }
+}
+
 document.addEventListener('DOMContentLoaded', () => {
   const loginSection = document.getElementById('login');
   const dashboard = document.getElementById('dashboard');
@@ -76,6 +103,9 @@ document.addEventListener('DOMContentLoaded', () => {
       document.getElementById('maps-link').href = mapsUrl;
     }
     fetchSuggestions(lat, lon);
+    if (currentDay && currentDay.accommodation) {
+      loadRoutes(lat, lon, currentDay.accommodation.address);
+    }
   }
 
   setLocationBtn.addEventListener('click', () => {
@@ -194,5 +224,5 @@ document.addEventListener('DOMContentLoaded', () => {
 });
 
 if (typeof module !== 'undefined' && module.exports) {
-  module.exports = { initDashboard };
+  module.exports = { initDashboard, loadRoutes };
 }

--- a/index.html
+++ b/index.html
@@ -30,6 +30,7 @@
       </div>
       <a id="maps-link" target="_blank">Directions to accommodation</a>
     </section>
+    <section id="routes"></section>
     <section id="itinerary"></section>
     <section id="free-time"></section>
     <section id="suggestions"></section>

--- a/package.json
+++ b/package.json
@@ -3,8 +3,7 @@
   "version": "1.0.0",
   "description": "Interactive dashboard for Europe trip itinerary",
   "scripts": {
-    "test": "node tests/logic.test.js && node tests/index.test.js"
-    "test": "node tests/logic.test.js && node tests/login.test.js",
+    "test": "node tests/logic.test.js && node tests/login.test.js && node tests/index.test.js && node tests/directions.test.js",
     "start": "node server.js"
   }
 }

--- a/tests/directions.test.js
+++ b/tests/directions.test.js
@@ -1,0 +1,45 @@
+const assert = require('assert');
+
+function createMockDocument() {
+  const elements = {};
+  return {
+    getElementById: (id) => {
+      if (!elements[id]) elements[id] = { innerHTML: '', textContent: '' };
+      return elements[id];
+    },
+    addEventListener: () => {},
+    elements
+  };
+}
+
+let mockDoc = createMockDocument();
+global.document = mockDoc;
+const { loadRoutes } = require('../app.js');
+
+(async () => {
+  // Successful fetch
+  mockDoc = createMockDocument();
+  global.document = mockDoc;
+  global.fetch = (url) => {
+    const mode = /mode=([^&]+)/.exec(url)[1];
+    const durations = { transit: '20 mins', walking: '60 mins', driving: '15 mins' };
+    return Promise.resolve({
+      json: () => Promise.resolve({ routes: [{ legs: [{ duration: { text: durations[mode] } }] }] })
+    });
+  };
+  await loadRoutes(1, 2, 'Some Place');
+  const html = document.getElementById('routes').innerHTML;
+  assert(html.includes('Transit: 20 mins'), 'Transit duration missing');
+  assert(html.includes('Walking: 60 mins'), 'Walking duration missing');
+  assert(html.includes('Taxi/Ride-share: 15 mins'), 'Taxi duration missing');
+  delete global.document; delete global.fetch;
+
+  // Failed fetch
+  mockDoc = createMockDocument();
+  global.document = mockDoc;
+  global.fetch = () => Promise.reject(new Error('fail'));
+  await loadRoutes(1, 2, 'Some Place');
+  assert.strictEqual(document.getElementById('routes').textContent, 'Could not load route information', 'Failure message missing');
+  delete global.document; delete global.fetch;
+  console.log('Directions tests passed');
+})();

--- a/tests/logic.test.js
+++ b/tests/logic.test.js
@@ -1,5 +1,6 @@
 const assert = require('assert');
-const { getItineraryForDate, getFreeTimeBlocks, haversineDistance } = require('../logic.js');
+const { getItineraryForDate, getFreeTimeBlocks, haversineDistance, getLocalDateString } = require('../logic.js');
+const itinerary = require('../itinerary.js');
 
 function createMockDocument() {
   const elements = {};
@@ -12,9 +13,6 @@ function createMockDocument() {
     elements
   };
 }
-const { getItineraryForDate, getFreeTimeBlocks } = require('../logic.js');
-const itinerary = require('../itinerary.js');
-const { getItineraryForDate, getFreeTimeBlocks, getLocalDateString } = require('../logic.js');
 
 // Test itinerary retrieval from object structure
 const directDay = itinerary['2023-09-14'];


### PR DESCRIPTION
## Summary
- Fetch directions for transit, walking, and ride-share modes and render routes with external map links
- Show a fallback message when directions API fails
- Mock directions API responses in new tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a81b166a5c8328bd83ec5a0d3d9c2a