### PR TITLE
feat: add optional HTTPS enforcement

### DIFF
--- a/server.js
+++ b/server.js
@@ -10,6 +10,7 @@ const hashedPassword =
   crypto.createHash('sha256').update('3urotrip_1997!').digest('hex');
 const jwtSecret = process.env.JWT_SECRET || 'secret';
 const TOKEN_EXPIRY_SECONDS = parseInt(process.env.TOKEN_EXPIRY_SECONDS, 10) || 3600;
+const enforceHttps = process.env.ENFORCE_HTTPS === 'true';
 
 const sessions = new Map(); // token -> expiry timestamp
 const rateLimit = new Map(); // ip -> { count, start }
@@ -149,7 +150,7 @@ function handleApi(req, res) {
 
 const server = http.createServer((req, res) => {
   const isSecure = req.headers['x-forwarded-proto'] === 'https' || req.socket.encrypted;
-  if (!isSecure) {
+  if (enforceHttps && !isSecure) {
     res.writeHead(301, { Location: `https://${req.headers.host}${req.url}` });
     res.end();
     return;
@@ -178,5 +179,4 @@ if (require.main === module) {
   server.listen(3000, () => console.log('Server running on port 3000'));
 }
 
-module.exports = { server, sessions, commitPinsFile };
-module.exports = { server, sessions, rateLimit };
+module.exports = { server, sessions, commitPinsFile, rateLimit };


### PR DESCRIPTION
## Summary
- make HTTPS redirect optional via `ENFORCE_HTTPS` environment variable so local HTTP access works
- export all server utilities from one module entry

## Testing
- `npm test` *(fails: Identifier 'getItineraryForDate' has already been declared in tests/logic.test.js)*
- `node tests/login.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68a821cb4fe48328a4740c4e5750a8fb