### PR TITLE
Revamp dashboard layout and streamline map logic

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,29 +12,31 @@
 </head>
 <body>
   <div id="dashboard" role="main">
-    <header>
+    <header class="top-bar">
       <h1>Europe Trip Dashboard</h1>
+      <nav id="date-nav" aria-label="Select date">
+        <button id="prev-date" type="button">Previous</button>
+        <input id="date-picker" type="date" />
+        <button id="next-date" type="button">Next</button>
+      </nav>
     </header>
-    <section id="current-location" role="region" aria-labelledby="current-location-heading">
-      <h2 id="current-location-heading">Current Location</h2>
-      <p id="location" aria-live="polite">Detecting...</p>
-      <div id="manual-location-container" style="display:none">
-        <input id="manual-location" placeholder="lat,lon" aria-label="Enter latitude and longitude" />
-        <button id="set-location" type="button" aria-label="Set location manually">Set Location</button>
-      </div>
-      <a id="maps-link" href="#" target="_blank" rel="noopener" aria-label="Directions to accommodation">Directions to accommodation</a>
-      <div id="map" style="height:300px"></div>
-    </section>
-    <div id="date-nav">
-      <button id="prev-date" type="button">Previous</button>
-      <input id="date-picker" type="date" />
-      <button id="next-date" type="button">Next</button>
-    </div>
-    <section id="routes"></section>
-    <section id="itinerary" role="region" aria-label="Itinerary"></section>
-    <section id="free-time" role="region" aria-label="Free Time"></section>
-    <section id="suggestions" role="region" aria-label="Suggestions"></section>
-    <section id="pinned"></section>
+    <main>
+      <section id="current-location" role="region" aria-labelledby="current-location-heading">
+        <h2 id="current-location-heading">Current Location</h2>
+        <p id="location" aria-live="polite">Detecting...</p>
+        <div id="manual-location-container" style="display:none">
+          <input id="manual-location" placeholder="lat,lon" aria-label="Enter latitude and longitude" />
+          <button id="set-location" type="button" aria-label="Set location manually">Set Location</button>
+        </div>
+        <a id="maps-link" href="#" target="_blank" rel="noopener" aria-label="Directions to accommodation">Directions to accommodation</a>
+        <div id="map" style="height:300px"></div>
+      </section>
+      <section id="routes"></section>
+      <section id="itinerary" role="region" aria-label="Itinerary"></section>
+      <section id="free-time" role="region" aria-label="Free Time"></section>
+      <section id="suggestions" role="region" aria-label="Suggestions"></section>
+      <section id="pinned"></section>
+    </main>
   </div>
   <script src="itinerary.js"></script>
   <script src="logic.js"></script>

--- a/styles.css
+++ b/styles.css
@@ -20,15 +20,32 @@ body {
   padding: env(safe-area-inset-top) env(safe-area-inset-right) env(safe-area-inset-bottom) env(safe-area-inset-left);
 }
 
-header {
+header.top-bar {
   background: var(--color-primary);
   color: #fff;
   padding: var(--spacing-md);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--spacing-sm);
   text-align: center;
 }
 
+#date-nav {
+  display: flex;
+  gap: var(--spacing-sm);
+  align-items: center;
+}
+
 #dashboard {
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+}
+
+#dashboard main {
   display: grid;
+  flex: 1;
   padding: var(--spacing-md);
   gap: var(--spacing-md);
   grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));


### PR DESCRIPTION
## Summary
- restructure dashboard header with integrated date navigation and semantic main content
- modernize responsive styles using flex and grid layouts
- consolidate suggestion fetching and relax map token requirement

## Testing
- `npm test`
- `node tests/dateNavigation.test.js`
- `node tests/directions.test.js`
- `node tests/display.test.js`
- `node tests/map.test.js`
- `node tests/pins.test.js`
- `node tests/timezone.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68a835cdd8d083289b9e8c24ab24a409