### PR TITLE
Expose itinerary API and render on dashboard

### DIFF
--- a/app.js
+++ b/app.js
@@ -169,6 +169,24 @@ function displayItinerary(day) {
   }
 }
 
+function renderItineraryList(entries) {
+  const container = document.getElementById('itinerary-list');
+  if (!container) return;
+  container.innerHTML = '';
+  (entries || []).forEach(item => {
+    const details = document.createElement('details');
+    const summary = document.createElement('summary');
+    summary.textContent = `${item.date} - ${item.location}`;
+    details.appendChild(summary);
+    if (item.notes) {
+      const p = document.createElement('p');
+      p.textContent = item.notes;
+      details.appendChild(p);
+    }
+    container.appendChild(details);
+  });
+}
+
 function displayPinned(date) {
   const key = `pinned-${date}`;
   const items = JSON.parse((typeof localStorage !== 'undefined' && localStorage.getItem(key)) || '[]');
@@ -331,10 +349,17 @@ document.addEventListener('DOMContentLoaded', () => {
     d.setDate(d.getDate() + 1);
     initDashboard(d.toISOString().split('T')[0]);
   });
+  fetch('/api/itinerary')
+    .then(res => res.json())
+    .then(data => renderItineraryList(data))
+    .catch(() => {
+      const c = document.getElementById('itinerary-list');
+      if (c) c.textContent = 'Could not load itinerary';
+    });
   initDashboard();
 });
 
 if (typeof module !== 'undefined' && module.exports) {
-  module.exports = { initDashboard, displayItinerary, loadRoutes };
+  module.exports = { initDashboard, displayItinerary, loadRoutes, renderItineraryList };
 }
 

--- a/index.html
+++ b/index.html
@@ -33,6 +33,7 @@
       </section>
       <section id="routes"></section>
       <section id="itinerary" role="region" aria-label="Itinerary"></section>
+      <section id="itinerary-list" role="region" aria-label="Itinerary Overview"></section>
       <section id="free-time" role="region" aria-label="Free Time"></section>
       <section id="suggestions" role="region" aria-label="Suggestions"></section>
       <section id="pinned"></section>

--- a/itinerary.js
+++ b/itinerary.js
@@ -391,9 +391,27 @@
     return acc;
   }, {});
 
+  // Flatten entries for API consumption
+  const itineraryEntries = itineraryArray.map(day => {
+    let location = '';
+    if (day.accommodation && day.accommodation.name) {
+      location = day.accommodation.name;
+    } else if (day.travel) {
+      location = day.travel;
+    }
+    const notes = [];
+    if (day.travel) notes.push(day.travel);
+    if (Array.isArray(day.activities) && day.activities.length) {
+      notes.push(day.activities.map(a => a.title).join(', '));
+    }
+    return { date: day.date, location, notes: notes.join(' | ') };
+  });
+
   if (typeof module !== 'undefined' && module.exports) {
     module.exports = itinerary;
+    module.exports.entries = itineraryEntries;
   } else {
     global.itinerary = itinerary;
+    global.itineraryEntries = itineraryEntries;
   }
 })(this);

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "description": "Interactive dashboard for Europe trip itinerary",
   "scripts": {
-    "test": "node tests/logic.test.js && node tests/index.test.js && node tests/accessibility.test.js",
+    "test": "node tests/logic.test.js && node tests/index.test.js && node tests/accessibility.test.js && node tests/itineraryEndpoint.test.js && node tests/itineraryRender.test.js",
     "start": "node server.js"
   }
 }

--- a/server.js
+++ b/server.js
@@ -1,6 +1,7 @@
 const http = require('http');
 const fs = require('fs');
 const path = require('path');
+const itinerary = require('./itinerary.js');
 
 const pinsFile = path.join(__dirname, 'pins.json');
 
@@ -51,6 +52,12 @@ function handleApi(req, res) {
     const pins = readPins();
     res.writeHead(200, { 'Content-Type': 'application/json' });
     res.end(JSON.stringify(pins));
+    return true;
+  }
+  if (req.method === 'GET' && req.url === '/api/itinerary') {
+    const entries = itinerary.entries || [];
+    res.writeHead(200, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify(entries));
     return true;
   }
   return false;

--- a/styles.css
+++ b/styles.css
@@ -131,3 +131,15 @@ button:focus {
   }
 }
 
+#itinerary-list details {
+  margin-bottom: var(--spacing-sm);
+  border: 1px solid #ccc;
+  border-radius: var(--radius);
+  padding: var(--spacing-sm);
+}
+
+#itinerary-list summary {
+  font-weight: 600;
+  cursor: pointer;
+}
+

--- a/tests/itineraryEndpoint.test.js
+++ b/tests/itineraryEndpoint.test.js
@@ -1,0 +1,26 @@
+const assert = require('assert');
+const { server } = require('../server.js');
+
+async function run() {
+  await new Promise((resolve, reject) => {
+    const listener = server.listen(0, async () => {
+      const port = listener.address().port;
+      try {
+        const res = await fetch(`http://localhost:${port}/api/itinerary`);
+        assert.strictEqual(res.status, 200, 'should return 200');
+        const data = await res.json();
+        assert(Array.isArray(data), 'should return an array');
+        assert(data.length > 0, 'array should not be empty');
+        assert.ok(data[0].date, 'entries should have date');
+        listener.close();
+        console.log('itinerary endpoint tests passed');
+        resolve();
+      } catch (e) {
+        listener.close();
+        reject(e);
+      }
+    });
+  });
+}
+
+run().catch(err => { console.error(err); process.exit(1); });

--- a/tests/itineraryRender.test.js
+++ b/tests/itineraryRender.test.js
@@ -1,0 +1,39 @@
+const assert = require('assert');
+
+function createMockDocument() {
+  const elements = {};
+  function createElement(tag) {
+    return {
+      tagName: tag.toUpperCase(),
+      children: [],
+      textContent: '',
+      appendChild(child) { this.children.push(child); },
+      setAttribute(name, value) { if (name === 'id') elements[value] = this; },
+      addEventListener() {}
+    };
+  }
+  return {
+    createElement,
+    getElementById(id) {
+      if (!elements[id]) elements[id] = createElement('div');
+      return elements[id];
+    },
+    elements,
+    addEventListener() {}
+  };
+}
+
+const document = createMockDocument();
+global.document = document;
+
+const { renderItineraryList } = require('../app.js');
+
+renderItineraryList([
+  { date: '2023-09-12', location: 'Paris', notes: 'Arrive' }
+]);
+
+const container = document.getElementById('itinerary-list');
+assert.strictEqual(container.children.length, 1, 'Itinerary item not rendered');
+const summary = container.children[0].children[0];
+assert(summary.textContent.includes('2023-09-12'), 'Date missing in summary');
+console.log('itinerary render tests passed');


### PR DESCRIPTION
## Summary
- parse itinerary data into flat entries and export for API use
- provide `/api/itinerary` endpoint serving the structured itinerary
- fetch and render itinerary list with collapsible items on page load
- style itinerary list for readability and add tests for API and UI rendering

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a83c6a69c48328bd0047e6403ca778